### PR TITLE
Pullrequests/to/upstream/2020 1221

### DIFF
--- a/HLAirships/HLEnvelope.cs
+++ b/HLAirships/HLEnvelope.cs
@@ -281,21 +281,18 @@ namespace HLAirships
 
 		public override void OnAwake()
 		{
-            if (!HighLogic.LoadedSceneIsEditor && !HighLogic.LoadedSceneIsFlight)
-                return;
+			/// Constructor style setup. 
+			/// Called in the Part\'s Awake method.  
+			/// The model may not be built by this point. 
 
-        this.objGravity = new GameObject();
-        this.objUp = new GameObject();
-        this.objPosition = new GameObject();
-        this.objUpProjected = new GameObject();
-        this.objPositionProjected = new GameObject();
+			this.objGravity = new GameObject();
+			this.objUp = new GameObject();
+			this.objPosition = new GameObject();
+			this.objUpProjected = new GameObject();
+			this.objPositionProjected = new GameObject();
 
-        /// Constructor style setup. 
-        /// Called in the Part\'s Awake method.  
-        /// The model may not be built by this point. 
-
-        // Set starting animation state
-        Debug.Log("Set Envelope Animation");
+			// Set starting animation state
+			Debug.Log("Set Envelope Animation");
 			if (animationState == 0 || targetBuoyantVessel == 0)
 			{
 				// If it does not have animation start it "opened"
@@ -438,9 +435,6 @@ namespace HLAirships
 
 		public override void OnStart(StartState state)
 		{
-            if (!HighLogic.LoadedSceneIsEditor && !HighLogic.LoadedSceneIsFlight)
-                return;
-
 			// OnFlightStart seems to have been removed
 			/// Called during the Part startup. 
 			/// StartState gives flag values of initial state

--- a/HLAirships/HLEnvelope.cs
+++ b/HLAirships/HLEnvelope.cs
@@ -487,6 +487,9 @@ namespace HLAirships
 			/// Called ONLY when Part is ACTIVE!
 			/// 
 
+			if (!HighLogic.LoadedSceneIsEditor && !HighLogic.LoadedSceneIsFlight)
+				return;
+
 			if (leadEnvelope == this.part) leadEnvelopeUpdate();
 
 			// Update buoyancy properties


### PR DESCRIPTION
Hi!

This fixes the Life Cycle of the code used to fix HLEnvelope to run on KSP >= 1.8 .

The OnStart should be executed no matter what, otherwise the Module will be inconsistent and risk a NRE.

And once OnUpdate is inhibited to be called in anything but Editor and Flight, OnFixedUpdate should be too - if the part is not flying neither being edited, there's no need to update the Envelope on every simulation tick, the same way you don't need to animate the envelope on every frame update.

Cheers.